### PR TITLE
Repeat on hold button behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 cfg-if = "1.0.0"
 
 embassy-time = { version = "0.4.0" }
+embassy-futures = { version = "0.1.2" }
 embedded-hal-async = "1.0.0"
 embedded-hal = "1.0.0"
 defmt = { version = "0.3.5", optional = true }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Async button handling crate for `no_std` environments. Built around `embedded-ha
 - [x] Debouncing
 - [x] Detect single and multiple short presses
 - [x] Detect long presses
+  - Optionally emit short presses on a specified interval during a long press (repeat-on-hold behavior)
 - [ ] Detect sequences of short and long presses or multiple long presses. Open an issue if this would be useful to you, or submit a PR!
 
 ## Example

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,10 @@ pub struct ButtonConfig {
     pub double_click: Duration,
     /// Time the button is held before a long press is detected.
     pub long_press: Duration,
+    /// If this is Some(), then a long press will cause short presses to be
+    /// emitted repeatedly on this interval until the button is released.
+    /// A long press event will also be emitted at the start of the series.
+    pub held_repeat_interval: Option<Duration>,
     /// Button direction.
     pub mode: Mode,
 }
@@ -21,12 +25,14 @@ impl ButtonConfig {
         debounce: Duration,
         double_click: Duration,
         long_press: Duration,
+        held_repeat_interval: Option<Duration>,
         mode: Mode,
     ) -> Self {
         Self {
             debounce,
             double_click,
             long_press,
+            held_repeat_interval,
             mode,
         }
     }
@@ -38,6 +44,7 @@ impl Default for ButtonConfig {
             debounce: Duration::from_millis(10),
             double_click: Duration::from_millis(350),
             long_press: Duration::from_millis(1000),
+            held_repeat_interval: None,
             mode: Mode::default(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ where
                 if let Some(repeat_interval) = self.config.held_repeat_interval {
                     match embassy_futures::select::select(
                         self.wait_for_release(),
-                        Timer::after(repeat_interval)
+                        delay(repeat_interval)
                     ).await {
                         Either::First(_) => {},
                         Either::Second(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(missing_docs)]
 
 pub use config::{ButtonConfig, Mode};
+use embassy_futures::select::Either;
 
 mod config;
 
@@ -143,8 +144,21 @@ where
                 None
             }
 
-            State::PendingRelease => {
-                self.wait_for_release().await;
+            State::PendingRelease => 'pending: {
+                if let Some(repeat_interval) = self.config.held_repeat_interval {
+                    match embassy_futures::select::select(
+                        self.wait_for_release(),
+                        Timer::after(repeat_interval)
+                    ).await {
+                        Either::First(_) => {},
+                        Either::Second(_) => {
+                            break 'pending Some(ButtonEvent::ShortPress { count: 1 })
+                        }
+                    }
+                } else {
+                    self.wait_for_release().await;
+                }
+
                 self.debounce_delay().await;
                 if self.is_pin_released() {
                     self.state = State::Idle;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,6 +10,7 @@ const CONFIG: ButtonConfig = ButtonConfig {
     debounce: Duration::from_millis(10),
     double_click: Duration::from_millis(100),
     long_press: Duration::from_millis(200),
+    held_repeat_interval: None,
     mode: Mode::PullUp,
 };
 

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -10,8 +10,35 @@ const CONFIG: ButtonConfig = ButtonConfig {
     debounce: Duration::from_millis(10),
     double_click: Duration::from_millis(100),
     long_press: Duration::from_millis(200),
+    held_repeat_interval: None,
     mode: Mode::PullUp,
 };
+
+#[tokio::test]
+async fn held_repeat() {
+    let mut pin = MockPin::new();
+    let mut button = {
+        let pin = pin.clone();
+        Button::new(pin, ButtonConfig {
+            held_repeat_interval: Some(Duration::from_millis(100)),
+            ..CONFIG
+        })
+    };
+
+    tokio::spawn(async move {
+        pin.set_low().await;
+        // long enough to trigger the long press, then two repeated short presses
+        sleep_millis(210+110+110).await;
+        pin.set_high().await;
+    });
+    
+    // long press gets emitted at the start of the series
+    assert_matches!(button.update().await, ButtonEvent::LongPress);
+    // it is only held long enough for 2 repeats, and they are NOT double or triple-clicks
+    assert_matches!(button.update().await, ButtonEvent::ShortPress{count: 1});
+    assert_matches!(button.update().await, ButtonEvent::ShortPress{count: 1});
+    verify_no_event(&mut button).await;
+}
 
 #[tokio::test]
 async fn short_press() {


### PR DESCRIPTION
This PR adds a repeat-on-hold feature. It is enabled by setting the new `held_repeat_interval` config field to `Some(Duration)` and is disabled otherwise. When the button is held down for the `long_press` duration, it emits a `ButtonEvent::LongPress` as usual. Then, for the duration the button continues to be held, a `ButtonEvent::ShortPress{count: 1}` will be emitted every `held_repeat_interval` until it is released.

This functionality is useful for settings buttons, as it allows a user to press and hold an up or down button instead of needing to rapidly mash and wear it out. Surely, there are also other applications.

This is an API-breaking change, since a field is added to `ButtonConfig`. It also adds a dependency on `embassy-futures` for `use embassy_futures::select::{select, Either}`. Since there is already an `embassy-time` dependency, I figure that another well-known crate from the same ecosystem is fine.

I also added a unit test for the feature.